### PR TITLE
Add conversion_workflow to watcher script

### DIFF
--- a/watcher.py
+++ b/watcher.py
@@ -123,11 +123,11 @@ def main():
                 library_dataset = find_library_dataset(raw_file_path)
                 if library_dataset:
                     log.info("Dataset has a corresponding library entry")
-                    # time to trigger conversion workflow
+                    run_conversion_workflow(library_dataset, raw_file_path)
                 else:
                     log.info("Importing dataset to library.")
                     library_dataset = link_to_data_library(raw_file_path)
-                    # time to trigger conversion workflow
+                    run_conversion_workflow(library_dataset, raw_file_path)
             else:
                 # File is already converted. One tea please.
                 pass

--- a/watcher.py
+++ b/watcher.py
@@ -59,8 +59,18 @@ def find_library_dataset(raw_file_path):
     return library_dataset
 
 
-def run_conversion_workflow():
-    pass
+def run_conversion_workflow(library_dataset, raw_file_path):
+    #WORKFLOW_ID = create a workflow in galaxy
+    workflow = galaxy.workflows.WorkflowClient(gi)
+    raw_dir, raw_file = os.path.split(raw_file_path)
+    profile_dir = os.path.split(raw_dir)[0]
+    raw_file_id = library_dataset["id"]
+    workflow.invoke_workflow(workflow_id=WORKFLOW_ID, 
+        inputs={'0': {'id': raw_file_id, 'src': 'ld'}},
+        params={'2': {'export_dir': profile_dir}})
+        #can create a dedicated history so we don't get a new one each time the workflow is run
+    
+    #then clear up the history
 
 
 def link_to_data_library(raw_file_path):


### PR DESCRIPTION
* All of the workflow parameters except for export path are static for now. Though it won't be a big of a deal to make them dynamic.
* A workflow is to be created in galaxy GUI and copied to the script.
* I used [adjusted](https://github.com/RECETOX/galaxytools/pull/45) 'export to path' tool for testing.
* [Here's](https://drive.google.com/file/d/1TjGctPfeQCAftBWM8ck2J49BL6Raj2if/view?usp=sharing) the layout of the workflow